### PR TITLE
Add support for 1.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18.1
-	yarn_mappings=1.18.1+build.17
-	loader_version=0.12.12
+    # check these on https://fabricmc.net/versions.html
+    minecraft_version=1.18.2
+    yarn_mappings=1.18.2+build.2
+    loader_version=0.13.3
 
 # Mod Properties
-	mod_version = 1.0.4
-	version_type = RELEASE
-	maven_group = com.qendolin
-	archives_base_name = better-clouds
+    mod_version = 1.0.5
+    version_type = RELEASE
+    maven_group = com.qendolin
+    archives_base_name = better-clouds
 
 # Dependencies
-	fabric_version=0.45.1+1.18
-	modmenu_version=3.0.1
+    fabric_version=0.48.0+1.18.2
+    modmenu_version=3.0.1
 
 # Compat
-	sodium_extra_version=mc1.18-0.3.7
+    sodium_extra_version=mc1.18.2-0.4.2


### PR DESCRIPTION
Thankfully, nothing had to be rewritten for 1.18.2, so this is just a few version bumps in the `gradle.properties`

Bump to 1.0.5