### PR TITLE
Fix Iris 1.7.0 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.parallel=true
     loader_version=0.15.7
 
 # Mod Properties
-    mod_version = 1.5.7
+    mod_version = 1.5.8
     version_type = RELEASE
     maven_group = com.qendolin
     archives_base_name = better-clouds
@@ -22,4 +22,4 @@ org.gradle.parallel=true
 
 # Compat
     sodium_extra_version=mc1.20.4-0.5.4
-	iris_version=1.6.17+1.20.4
+	iris_version=1.7.0+1.20.4

--- a/src/main/java/com/qendolin/betterclouds/compat/IrisCompat.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/IrisCompat.java
@@ -2,13 +2,13 @@ package com.qendolin.betterclouds.compat;
 
 import com.qendolin.betterclouds.mixin.optional.ExtendedShaderAccessor;
 import com.qendolin.betterclouds.mixin.optional.FallbackShaderAccessor;
-import net.coderbot.iris.Iris;
-import net.coderbot.iris.gl.framebuffer.GlFramebuffer;
-import net.coderbot.iris.pipeline.WorldRenderingPipeline;
-import net.coderbot.iris.pipeline.newshader.ExtendedShader;
-import net.coderbot.iris.pipeline.newshader.NewWorldRenderingPipeline;
-import net.coderbot.iris.pipeline.newshader.ShaderKey;
-import net.coderbot.iris.pipeline.newshader.fallback.FallbackShader;
+import net.irisshaders.iris.Iris;
+import net.irisshaders.iris.gl.framebuffer.GlFramebuffer;
+import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
+import net.irisshaders.iris.pipeline.programs.ExtendedShader;
+import net.irisshaders.iris.pipeline.IrisRenderingPipeline;
+import net.irisshaders.iris.pipeline.programs.ShaderKey;
+import net.irisshaders.iris.pipeline.programs.FallbackShader;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gl.ShaderProgram;
 
@@ -22,7 +22,7 @@ public class IrisCompat {
 
     public static void bindFramebuffer() {
         WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipelineNullable();
-        if (pipeline instanceof NewWorldRenderingPipeline corePipeline) {
+        if (pipeline instanceof IrisRenderingPipeline corePipeline) {
             ShaderProgram program = corePipeline.getShaderMap().getShader(ShaderKey.CLOUDS);
             GlFramebuffer before = null, after = null;
             if (program instanceof ExtendedShader extended) {

--- a/src/main/java/com/qendolin/betterclouds/mixin/optional/ExtendedShaderAccessor.java
+++ b/src/main/java/com/qendolin/betterclouds/mixin/optional/ExtendedShaderAccessor.java
@@ -1,7 +1,7 @@
 package com.qendolin.betterclouds.mixin.optional;
 
-import net.coderbot.iris.gl.framebuffer.GlFramebuffer;
-import net.coderbot.iris.pipeline.newshader.ExtendedShader;
+import net.irisshaders.iris.gl.framebuffer.GlFramebuffer;
+import net.irisshaders.iris.pipeline.programs.ExtendedShader;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 

--- a/src/main/java/com/qendolin/betterclouds/mixin/optional/FallbackShaderAccessor.java
+++ b/src/main/java/com/qendolin/betterclouds/mixin/optional/FallbackShaderAccessor.java
@@ -1,7 +1,7 @@
 package com.qendolin.betterclouds.mixin.optional;
 
-import net.coderbot.iris.gl.framebuffer.GlFramebuffer;
-import net.coderbot.iris.pipeline.newshader.fallback.FallbackShader;
+import net.irisshaders.iris.gl.framebuffer.GlFramebuffer;
+import net.irisshaders.iris.pipeline.programs.FallbackShader;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -42,6 +42,7 @@
     "sodium": "*"
   },
   "breaks": {
-    "vulkanmod": "*"
+    "vulkanmod": "*",
+    "iris": "<1.7.0"
   }
 }


### PR DESCRIPTION
Fixes support for Iris 1.7.0's new class names after its refactor. (fixes #82)
The mod's config page also has an issue with YACL >3.4.0 due to its new custom tab API, which would require a rewrite of it. I haven't been able to do anything about that as that is beyond me, so just consider either using YACL 3.3.1 or not opening the settings for the time being.