### PR TITLE
Increase max distance to 256

### DIFF
--- a/src/main/java/com/qendolin/betterclouds/ConfigGUI.java
+++ b/src/main/java/com/qendolin/betterclouds/ConfigGUI.java
@@ -113,7 +113,7 @@ public class ConfigGUI {
             .build();
         this.distance = createOption(float.class, "distance")
             .binding(defaults.distance, () -> config.distance, val -> config.distance = val)
-            .customController(opt -> new FloatSliderController(opt, 1, 4, 0.05f, ConfigGUI::formatAsTimes))
+            .customController(opt -> new FloatSliderController(opt, 1, 256, 0.05f, ConfigGUI::formatAsTimes))
             .build();
         this.fuzziness = createOption(float.class, "fuzziness")
             .binding(defaults.fuzziness, () -> config.fuzziness, val -> config.fuzziness = val)


### PR DESCRIPTION
This increases the max cloud distance to 256, which can improve compatibility for mods like [Distant Horizons](https://gitlab.com/jeseibel/distant-horizons) and [Voxy](https://github.com/MCRcortex/voxy). This is just a quick fix, it probably shouldn't be permanent.