### PR TITLE
fix cloud flickering when ars nouveau is present

### DIFF
--- a/src/main/java/com/qendolin/betterclouds/clouds/Renderer.java
+++ b/src/main/java/com/qendolin/betterclouds/clouds/Renderer.java
@@ -133,6 +133,11 @@ public class Renderer implements AutoCloseable {
             return PrepareResult.NO_RENDER;
         }
 
+        // This doesn't make the Skyweave block work, but it prevents larger issues
+        if (ArsNouveauCompat.isSkyTextureCloudsRendering()) {
+            return PrepareResult.NO_RENDER;
+        }
+
         DimensionEffects effects = world.getDimensionEffects();
         cloudsHeight = effects.getCloudsHeight();
 
@@ -221,10 +226,7 @@ public class Renderer implements AutoCloseable {
 
         // Draw to game framebuffer
         VanillaRenderTarget rt = new VanillaRenderTarget(client, config);
-        boolean isArsRendering = ArsNouveauCompat.isArsRendering();
-        if (!isArsRendering) {
-            rt.begin();
-        }
+        rt.begin();
 
         // Render debug stuff
         getProfiler().swap("draw_debug");
@@ -236,9 +238,7 @@ public class Renderer implements AutoCloseable {
 
         // Restore state
         getProfiler().swap("render_cleanup");
-        if (!isArsRendering) {
-            rt.end();
-        }
+        rt.end();
         res.generator().unbind();
         GlStateManager._disableBlend();
         GlStateManager._enableDepthTest();

--- a/src/main/java/com/qendolin/betterclouds/clouds/Renderer.java
+++ b/src/main/java/com/qendolin/betterclouds/clouds/Renderer.java
@@ -3,6 +3,7 @@ package com.qendolin.betterclouds.clouds;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.qendolin.betterclouds.BetterCloudsStatic;
 import com.qendolin.betterclouds.clouds.shaders.ShaderParameters;
+import com.qendolin.betterclouds.compat.ArsNouveauCompat;
 import com.qendolin.betterclouds.compat.DistantHorizonsCompat;
 import com.qendolin.betterclouds.compat.IrisCompat;
 import com.qendolin.betterclouds.config.Config;
@@ -220,7 +221,10 @@ public class Renderer implements AutoCloseable {
 
         // Draw to game framebuffer
         VanillaRenderTarget rt = new VanillaRenderTarget(client, config);
-        rt.begin();
+        boolean isArsRendering = ArsNouveauCompat.isArsRendering();
+        if (!isArsRendering) {
+            rt.begin();
+        }
 
         // Render debug stuff
         getProfiler().swap("draw_debug");
@@ -232,7 +236,9 @@ public class Renderer implements AutoCloseable {
 
         // Restore state
         getProfiler().swap("render_cleanup");
-        rt.end();
+        if (!isArsRendering) {
+            rt.end();
+        }
         res.generator().unbind();
         GlStateManager._disableBlend();
         GlStateManager._enableDepthTest();

--- a/src/main/java/com/qendolin/betterclouds/compat/ArsNouveauCompat.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/ArsNouveauCompat.java
@@ -1,0 +1,12 @@
+package com.qendolin.betterclouds.compat;
+
+public class ArsNouveauCompat {
+    private static final int STACK_DEPTH = 10;
+    public static boolean isArsRendering() {
+        if (!ModLoaded.ARS_NOUVEAU) {
+            return false;
+        }
+        StackWalker instance = StackWalker.getInstance();
+        return instance.walk(stream -> stream.limit(STACK_DEPTH).anyMatch(s -> s.getClassName().equals("com.hollingsworth.arsnouveau.client.SkyTextureHandler")));
+    }
+}

--- a/src/main/java/com/qendolin/betterclouds/compat/ArsNouveauCompat.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/ArsNouveauCompat.java
@@ -1,12 +1,12 @@
 package com.qendolin.betterclouds.compat;
 
 public class ArsNouveauCompat {
-    private static final int STACK_DEPTH = 10;
-    public static boolean isArsRendering() {
+    public static final ThreadLocal<Boolean> IS_SKY_TEXTURE_CLOUDS_RENDERING = ThreadLocal.withInitial(() -> false);
+
+    public static boolean isSkyTextureCloudsRendering() {
         if (!ModLoaded.ARS_NOUVEAU) {
             return false;
         }
-        StackWalker instance = StackWalker.getInstance();
-        return instance.walk(stream -> stream.limit(STACK_DEPTH).anyMatch(s -> s.getClassName().equals("com.hollingsworth.arsnouveau.client.SkyTextureHandler")));
+        return IS_SKY_TEXTURE_CLOUDS_RENDERING.get();
     }
 }

--- a/src/main/java/com/qendolin/betterclouds/compat/ModLoaded.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/ModLoaded.java
@@ -11,4 +11,5 @@ public abstract class ModLoaded {
     public static final boolean HEAD_IN_THE_CLOUDS = ModLoader.isModLoaded("head_in_the_clouds");
     public static final boolean SERENE_SEASONS = ModLoader.isModLoaded("sereneseasons");
     public static final boolean SODIUM_EXTRA = ModLoader.isModLoaded("sodium-extra");
+    public static final boolean ARS_NOUVEAU = ModLoader.isModLoaded("ars_nouveau");
 }

--- a/src/main/java/com/qendolin/betterclouds/mixin/OptionalMixinPlugin.java
+++ b/src/main/java/com/qendolin/betterclouds/mixin/OptionalMixinPlugin.java
@@ -15,6 +15,9 @@ public class OptionalMixinPlugin extends MixinPlugin {
         if (mixinClassName.endsWith("ExtendedShaderAccessor") || mixinClassName.endsWith("FallbackShaderAccessor")) {
             return ModLoaded.IRIS;
         }
+        if (mixinClassName.endsWith("ArsNouveauSkyTextureHandlerMixin")) {
+            return ModLoaded.ARS_NOUVEAU;
+        }
         return true;
     }
 }

--- a/src/main/java/com/qendolin/betterclouds/mixin/optional/ArsNouveauSkyTextureHandlerMixin.java
+++ b/src/main/java/com/qendolin/betterclouds/mixin/optional/ArsNouveauSkyTextureHandlerMixin.java
@@ -1,0 +1,28 @@
+package com.qendolin.betterclouds.mixin.optional;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.qendolin.betterclouds.compat.ArsNouveauCompat;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+
+@Pseudo
+@Mixin(targets = "com.hollingsworth.arsnouveau.client.SkyTextureHandler", remap = false)
+public class ArsNouveauSkyTextureHandlerMixin {
+
+    @SuppressWarnings("UnresolvedMixinReference")
+    @WrapOperation(method = "renderSky", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/client/renderer/LevelRenderer;renderClouds(Lcom/mojang/blaze3d/vertex/PoseStack;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;FDDD)V"))
+    private static void onRenderClouds(@Coerce Object instance, @Coerce Object poseStack, Matrix4f frustumMatrix, Matrix4f projectionMatrix, float partialTick, double camX, double camY, double camZ, Operation<Void> original) {
+        try {
+            ArsNouveauCompat.IS_SKY_TEXTURE_CLOUDS_RENDERING.set(true);
+            original.call(instance, poseStack, frustumMatrix, projectionMatrix, partialTick, camX, camY, camZ);
+        } finally {
+            ArsNouveauCompat.IS_SKY_TEXTURE_CLOUDS_RENDERING.set(false);
+        }
+    }
+}

--- a/src/main/resources/betterclouds.optional.mixins.json
+++ b/src/main/resources/betterclouds.optional.mixins.json
@@ -8,6 +8,7 @@
     "DimensionEffectsOverworldMixin",
     "ExtendedShaderAccessor",
     "FallbackShaderAccessor",
-    "BackgroundRendererMixinMixin"
+    "BackgroundRendererMixinMixin",
+    "ArsNouveauSkyTextureHandlerMixin"
   ]
 }


### PR DESCRIPTION
fixes: https://github.com/Qendolin/better-clouds/issues/130
this does not fix clouds/rain not being rendered in ars nouveau skyweaverblocks.