### PR TITLE
Fix Distant Horizons compatibility when using DH API v5 or v6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ dependencies {
 	}
 
 	include(implementation('gs.mclo:api:5.0.0'))
-	compileOnly "maven.modrinth:distanthorizonsapi:4.0.0"
+	compileOnly "maven.modrinth:distanthorizonsapi:6.1.0"
 	modCompileOnly "maven.modrinth:serene-seasons:${property('deps.serene_seasons')}"
 	modCompileOnly "maven.modrinth:enhanced-celestials:${property('deps.enhanced_celestials')}"
 	modCompileOnly "maven.modrinth:data-anchor:D3z4pTH6" // use fabric 1.21.1 version for all

--- a/src/main/java/com/qendolin/betterclouds/clouds/VanillaRenderTarget.java
+++ b/src/main/java/com/qendolin/betterclouds/clouds/VanillaRenderTarget.java
@@ -1,9 +1,12 @@
 package com.qendolin.betterclouds.clouds;
 
 
+import com.qendolin.betterclouds.BetterCloudsStatic;
 import com.qendolin.betterclouds.compat.IrisCompat;
 import com.qendolin.betterclouds.config.Config;
 import net.minecraft.client.MinecraftClient;
+
+import java.util.Arrays;
 import java.util.function.Supplier;
 
 //? if >=1.21.5 {
@@ -56,7 +59,7 @@ public class VanillaRenderTarget {
         //?} else {
         /*framebuffer.beginWrite(false);
         renderPhase = RenderPhaseAccessor.getCloudsTarget();
-        invokeRenderPhase(renderPhase, "startDrawing");
+        invokeRenderPhase(renderPhase, "setupRenderState");
         *///?}
     }
 
@@ -72,7 +75,7 @@ public class VanillaRenderTarget {
         }
         //?} else {
         /*if (renderPhase != null) {
-            invokeRenderPhase(renderPhase, "endDrawing");
+            invokeRenderPhase(renderPhase, "clearRenderState");
         }
         *///?}
     }
@@ -82,6 +85,8 @@ public class VanillaRenderTarget {
         try {
             renderPhase.getClass().getMethod(methodName).invoke(renderPhase);
         } catch (ReflectiveOperationException e) {
+            BetterCloudsStatic.getLogger().info(Arrays.toString(renderPhase.getClass().getMethods()), e);
+            BetterCloudsStatic.getLogger().error(e);
             throw new RuntimeException("Failed to call RenderPhase." + methodName, e);
         }
     }

--- a/src/main/java/com/qendolin/betterclouds/clouds/fog/FogProvider.java
+++ b/src/main/java/com/qendolin/betterclouds/clouds/fog/FogProvider.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 public interface FogProvider {
     //? if >=1.20.1 && <1.21.3
-    /*FogProvider instance = new FogProvider1201();*/
+    //FogProvider instance = new FogProvider1201();
     //? if >=1.21.3 && <1.21.6
     /*FogProvider instance = new FogProvider1213();*/
     //? if >=1.21.6

--- a/src/main/java/com/qendolin/betterclouds/compat/DistantHorizons5CompatImpl.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/DistantHorizons5CompatImpl.java
@@ -1,5 +1,3 @@
 package com.qendolin.betterclouds.compat;
-
-class DistantHorizons5CompatImpl extends DistantHorizons4CompatImpl {
-    // same as 4
+class DistantHorizons5CompatImpl extends DistantHorizons3CompatImpl {
 }

--- a/src/main/java/com/qendolin/betterclouds/compat/DistantHorizons6CompatImpl.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/DistantHorizons6CompatImpl.java
@@ -1,0 +1,19 @@
+package com.qendolin.betterclouds.compat;
+
+import com.seibel.distanthorizons.api.methods.events.DhApiEventRegister;
+import com.seibel.distanthorizons.api.methods.events.abstractEvents.DhApiAfterColorDepthTextureCreatedEvent;
+import com.seibel.distanthorizons.api.methods.events.sharedParameterObjects.DhApiEventParam;
+import com.seibel.distanthorizons.api.methods.events.sharedParameterObjects.DhApiTextureCreatedParam;
+
+class DistantHorizons6CompatImpl extends DistantHorizons3CompatImpl {
+    public DistantHorizons6CompatImpl() {
+        super();
+        DhApiEventRegister.on(DhApiAfterColorDepthTextureCreatedEvent.class,
+            new DhApiAfterColorDepthTextureCreatedEvent() {
+                @Override
+                public void onResize(DhApiEventParam<DhApiTextureCreatedParam> event) {
+                    textureCreateFlag = true;
+                }
+            });
+    }
+}

--- a/src/main/java/com/qendolin/betterclouds/compat/DistantHorizonsCompat.java
+++ b/src/main/java/com/qendolin/betterclouds/compat/DistantHorizonsCompat.java
@@ -42,11 +42,14 @@ public abstract class DistantHorizonsCompat {
         }
 
         try {
-            if (apiVersion == 5) {
-                BetterCloudsStatic.getLogger().info("Using EXPERIMENTAL DistantHorizons 5 compat.");
+            if (apiVersion == 6) {
+                BetterCloudsStatic.getLogger().info("Using EXPERIMENTAL DistantHorizons 6 compat. The game might crash!");
+                instance = new DistantHorizons6CompatImpl();
+            } else if (apiVersion == 5) {
+                BetterCloudsStatic.getLogger().info("Using EXPERIMENTAL DistantHorizons 5 compat. The game might crash!");
                 instance = new DistantHorizons5CompatImpl();
             } else if (apiVersion == 4) {
-                BetterCloudsStatic.getLogger().warn("Using EXPERIMENTAL DistantHorizons 4 compat. The game might crash!");
+                BetterCloudsStatic.getLogger().warn("Using DistantHorizons 4 compat");
                 instance = new DistantHorizons4CompatImpl();
             } else if (apiVersion == 3) {
                 BetterCloudsStatic.getLogger().info("Using DistantHorizons 3 compat");

--- a/src/main/java/com/qendolin/betterclouds/config/ShaderPresetLoader.java
+++ b/src/main/java/com/qendolin/betterclouds/config/ShaderPresetLoader.java
@@ -24,7 +24,7 @@ import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 //?}
 
 //? if <1.21.3
-/*import net.minecraft.util.profiler.Profiler;*/
+//import net.minecraft.util.profiler.Profiler;
 
 public class ShaderPresetLoader
 //? if fabric {

--- a/src/main/java/com/qendolin/betterclouds/gui/IssueReportScreen.java
+++ b/src/main/java/com/qendolin/betterclouds/gui/IssueReportScreen.java
@@ -1,5 +1,6 @@
 package com.qendolin.betterclouds.gui;
 
+import com.qendolin.betterclouds.BetterCloudsStatic;
 import com.qendolin.betterclouds.config.ConfigManager;
 import com.qendolin.betterclouds.telemetry.ITelemetry;
 import net.minecraft.client.gui.DrawContext;
@@ -12,7 +13,7 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.crash.CrashReport;
 
 //? if <1.21.2
-/*import net.minecraft.client.MinecraftClient;*/
+//import net.minecraft.client.MinecraftClient;
 
 public class IssueReportScreen extends Screen {
 
@@ -33,6 +34,7 @@ public class IssueReportScreen extends Screen {
         super(TITLE);
         this.details = details;
         this.cause = cause;
+        BetterCloudsStatic.getLogger().error("Error occured", cause);
     }
 
     @Override

--- a/src/main/java/com/qendolin/betterclouds/mixin/runtime/FogRendererMixin.java
+++ b/src/main/java/com/qendolin/betterclouds/mixin/runtime/FogRendererMixin.java
@@ -24,8 +24,8 @@ public abstract class FogRendererMixin {
         //? if >=1.21.11 {
         method = "applyFog(Lnet/minecraft/client/render/Camera;ILnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",
         //?} else {
-        /*method = "applyFog(Lnet/minecraft/client/render/Camera;IZLnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",*/
-        //?}
+        /*method = "applyFog(Lnet/minecraft/client/render/Camera;IZLnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",
+        *///?}
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/fog/FogRenderer;applyFog(Ljava/nio/ByteBuffer;ILorg/joml/Vector4f;FFFFFF)V", shift = At.Shift.AFTER)
     )
     private void captureFogData(CallbackInfoReturnable<Vector4f> cir, @Local(ordinal = 0) FogData fogData, @Share("fogData") LocalRef<FogData> fogDataRef) {
@@ -36,8 +36,8 @@ public abstract class FogRendererMixin {
         //? if >=1.21.11 {
         method = "applyFog(Lnet/minecraft/client/render/Camera;ILnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",
         //?} else {
-        /*method = "applyFog(Lnet/minecraft/client/render/Camera;IZLnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",*/
-        //?}
+        /*method = "applyFog(Lnet/minecraft/client/render/Camera;IZLnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",
+        *///?}
         at = @At("RETURN")
     )
     private Vector4f captureFogColor(Vector4f color, @Share("fogData") LocalRef<FogData> fogDataRef) {

--- a/versions/1.21.1-forge/gradle.properties
+++ b/versions/1.21.1-forge/gradle.properties
@@ -8,7 +8,7 @@ mod.version=1.7.19
     loom.yarn_patch_neoforge=1.21+build.4
 
 # Dependencies
-    loader.neoforge=21.1.69
+    loader.neoforge=21.1.228
     deps.yacl=3.8.0+1.21.1
     deps.minecraft=1.21.0,1.21.1
     deps.neoforge=[21.0.143,21.1),[21.1.1,21.2),


### PR DESCRIPTION
I was working on the multiversion branch thinking that was the one I should use, so the file for v5 compatibility was overwritten because it didn't exist on multiversion, but it's exactly the same functionally, and it's only three lines, so I didn't change it, and for v6, there were very minimal changes.

Closes #305 

Not that it's my business, but this might warrant a small release, particularly for 1.21.1, since the release of Aeronautics last week has a lot of people trying to use all three mods right now. In any case, thanks for the amazing mod!