### PR TITLE
fix: rewrite naming guidelines to remove unsupported trademark claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,16 @@ Read it [here](https://github.com/Qendolin/better-clouds/wiki).
 This software is licensed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/FAQ/).  
 The assets, except for the logo, are under [CC BY-SA](https://creativecommons.org/licenses/by-sa/4.0/).
 
-### Restrictions on Name and Logo use
+### Naming Guidelines
 
-I **do not grant permission** for the use of the name "Better Clouds" or its logo for publication of derivative works.  
-Derivative works **must have a clearly distinct name and logo** to avoid confusion with the official "Better Clouds".
+If you publish a fork, port, or derivative of this mod, please follow these guidelines to avoid confusion in the community:
+
+- **Use a distinct name** so users can tell it's an independent project and not an official release.
+- **Do not use the official logo or branding** — the logo artwork is protected by copyright.
+- **Clearly indicate** whether your project is an official or community build.
 
 #### Examples
 
-- "Better Clouds Forge", is too similar and can be confused as an official publication for Forge.
-- "Better Clouds Reforged", this is fine, as "Reforged" is a common term for unofficial ports to Forge.
-- "Better Clouds (Unofficial)", if this is where your imagination ends, this is also fine.
+- "Better Clouds Forge" — too similar; easily confused as an official Forge port.
+- "Better Clouds Reforged" — acceptable, as "Reforged" is a well-understood community convention.
+- "Cirrus Clouds" — fully distinct name; no issues.


### PR DESCRIPTION
## Summary

Replaces the "Restrictions on Name and Logo use" section in the README with reasonable Naming Guidelines that the community can actually follow.

## Problem

The previous section claimed the author does not grant permission to use the name "Better Clouds" for derivative works. This is not enforceable because:

- **Genericness** — "Better Clouds" is a descriptive, generic name that cannot be trademarked
- **Prior art** — many mods across different games use this naming pattern
- **Cliché naming** — "Better THING" is a community-wide pattern, not a unique brand

While the logo artwork IS protectable by copyright, the name itself is fair game.

## Changes

Replaced the restrictive language with a social-convention-based guideline that:

1. Asks forks to use a **distinct name** to avoid confusion
2. Protects the **logo/branding** (copyright) from unauthorized use
3. Provides clearer examples of acceptable vs. confusing names
4. Drops unenforceable claims that attract bad actors

Fixes #353