### PR TITLE
Fix stuttery looking clouds on long running worlds for OpenGL backend

### DIFF
--- a/common/src/main/java/com/qendolin/betterclouds/rendering/opengl/OpenGLRenderer.java
+++ b/common/src/main/java/com/qendolin/betterclouds/rendering/opengl/OpenGLRenderer.java
@@ -213,7 +213,7 @@ public class OpenGLRenderer extends CloudRenderer {
         glClearColor(0, 0, 0, 0);
         clearDepth();
         setDepthFuncGEqual();
-        drawCoverage(Math.floorMod(ticks, 320_000) + tickDelta, cam, frustumPos, frustum, fog);
+        drawCoverage(java.lang.Math.floorMod(ticks, 320_000) + tickDelta, cam, frustumPos, frustum, fog);
 
         // Draw to game framebuffer
         VanillaRenderTarget rt = new VanillaRenderTarget(client, config);

--- a/common/src/main/java/com/qendolin/betterclouds/rendering/opengl/OpenGLRenderer.java
+++ b/common/src/main/java/com/qendolin/betterclouds/rendering/opengl/OpenGLRenderer.java
@@ -213,7 +213,7 @@ public class OpenGLRenderer extends CloudRenderer {
         glClearColor(0, 0, 0, 0);
         clearDepth();
         setDepthFuncGEqual();
-        drawCoverage(ticks + tickDelta, cam, frustumPos, frustum, fog);
+        drawCoverage(Math.floorMod(ticks, 320_000) + tickDelta, cam, frustumPos, frustum, fog);
 
         // Draw to game framebuffer
         VanillaRenderTarget rt = new VanillaRenderTarget(client, config);


### PR DESCRIPTION
notably an issue on hermitcraft where the world ticks is very large causing floating point precision issues