### PR TITLE
Config copy crashes on final fields and prevent `IndexOutOfBoundsException` during noise sampling

### DIFF
--- a/common/src/main/java/com/qendolin/betterclouds/config/Configs.java
+++ b/common/src/main/java/com/qendolin/betterclouds/config/Configs.java
@@ -156,12 +156,15 @@ public final class Configs {
     private static SerialField createSerialField(Field field) {
         try {
             field.setAccessible(true);
+            MethodHandle getter = METHOD_LOOKUP.unreflectGetter(field);
+            MethodHandle setter = Modifier.isFinal(field.getModifiers()) ? null : METHOD_LOOKUP.unreflectSetter(field);
             return new SerialField(
                     field.getName(),
                     field.getType(),
                     field.getGenericType(),
-                    METHOD_LOOKUP.unreflectGetter(field),
-                    METHOD_LOOKUP.unreflectSetter(field)
+                    getter,
+                    setter,
+                    field
             );
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Failed to access @SerialEntry field " + field, e);
@@ -178,7 +181,7 @@ public final class Configs {
         }
     }
 
-    private record SerialField(String name, Class<?> type, Type genericType, MethodHandle getter, MethodHandle setter) {
+    private record SerialField(String name, Class<?> type, Type genericType, MethodHandle getter, MethodHandle setter, Field field) {
         private Object get(Object instance) {
             try {
                 return getter.invoke(instance);
@@ -189,7 +192,11 @@ public final class Configs {
 
         private void set(Object instance, Object value) {
             try {
-                setter.invoke(instance, value);
+                if (setter != null) {
+                    setter.invoke(instance, value);
+                } else {
+                    field.set(instance, value);
+                }
             } catch (Throwable throwable) {
                 throw new IllegalStateException("Failed to write @SerialEntry field " + name, throwable);
             }

--- a/common/src/main/java/com/qendolin/betterclouds/generator/Sampler.java
+++ b/common/src/main/java/com/qendolin/betterclouds/generator/Sampler.java
@@ -118,7 +118,7 @@ public class Sampler {
         // TODO: A vanilla like cloud distribution is not possible with this function
         if (detailNoises.size() > 1) {
             double regionNoiseValue = (regionNoise.getValue(x / REGION_SIZE, z / REGION_SIZE) * 0.5 + 0.5) * detailNoises.size();
-            int noiseInd = (int) regionNoiseValue;
+            int noiseInd = Mth.clamp((int) regionNoiseValue, 0, detailNoises.size() - 1);
             PerlinSimplexNoise noise1 = detailNoises.get(noiseInd), noise2 = detailNoises.get((noiseInd + 1) % detailNoises.size());
 
             value = Mth.lerp(


### PR DESCRIPTION
This PR fixes two critical runtime exceptions that cause game crashes during configuration updates and cloud noise generation.

### 1. Fix `IllegalAccessException` / `IllegalStateException` when copying `Config` instances (`Configs.java`)
* **Problem**: `MethodHandles.Lookup.unreflectSetter(field)` throws an `IllegalAccessException` when passed `final` fields (such as `Config.presets`, `Config.noisePresets`, `sereneSeasonsConfig`, and `fabricSeasonsConfig`). This exception was caught and rethrown as an `IllegalStateException`, causing a crash whenever `Configs.copy(...)` was executed (e.g., when initializing tasks in `ChunkedGenerator`).
* **Fix**: Check `Modifier.isFinal(field.getModifiers())` before attempting to unreflect a setter. If the field is `final`, the handle is set to `null` and `SerialField.set(...)` falls back to direct field mutation via `Field.set(instance, value)`.

### 2. Prevent `IndexOutOfBoundsException` during cloud noise sampling (`Sampler.java`)
* **Problem**: `regionNoiseValue` can evaluate to `detailNoises.size()` when `regionNoise.getValue(...)` returns `1.0` (or slightly higher due to floating-point precision). Casting to `int` set `noiseInd = detailNoises.size()`, leading to an `IndexOutOfBoundsException` when calling `detailNoises.get(noiseInd)` during cloud chunk generation.
* **Fix**: Clamp `noiseInd` within `[0, detailNoises.size() - 1]` using `Mth.clamp`.